### PR TITLE
Fixed DeprecationWarning when using Python-Markdown 3.x

### DIFF
--- a/MarkdownBlankLine/blankline.py
+++ b/MarkdownBlankLine/blankline.py
@@ -17,12 +17,10 @@ BLANKLINE_RE = r'\%\%'
 class BlankLineExtension(Extension):
     """Adds BLANKLINE_RE extension to Markdown class."""
     
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """Modifies inline patterns."""
-        br_tag = SubstituteTagPattern(BLANKLINE_RE, 'br')
-        md.inlinePatterns.add('ble', br_tag, '_begin')
+        md.inlinePatterns.register(SubstituteTagPattern(BLANKLINE_RE, 'br'), 'ble', 200)
         
-
 
 def makeExtension(configs=None):
     return BlankLineExtension(configs)


### PR DESCRIPTION
Updated the code to work with the new extension API provided by Python-Markdown 3.x, namely the following changes:

* `md_globals` keyword deprecated from extension API
* Homegrown `OrderedDict` has been replaced with a purpose-built `Registry`

Full changelog for v3.0.0:
https://python-markdown.github.io/changelog/#300-2018-09-21

These deprecations started generating errors in [v3.4.0](https://python-markdown.github.io/changelog/#340-2022-07-15).
